### PR TITLE
Fix fuel consumption calculation with full tank vs partial refuel tracking (Issue #86)

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -18,7 +18,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(openConnection());
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
   MigrationStrategy get migration {
@@ -43,12 +43,13 @@ class AppDatabase extends _$AppDatabase {
         ''');
       },
       onUpgrade: (Migrator m, int from, int to) async {
-        // Future migration logic will go here
-        // Example:
-        // if (from < 2) {
-        //   // Migration from v1 to v2
-        //   await m.addColumn(fuelEntries, fuelEntries.newColumn);
-        // }
+        if (from < 2) {
+          // Migration from v1 to v2: Add is_full_tank column
+          await m.addColumn(fuelEntries, fuelEntries.isFullTank);
+          
+          // Set all existing entries as full tank (backward compatibility)
+          await customStatement('UPDATE fuel_entries SET is_full_tank = 1 WHERE is_full_tank IS NULL');
+        }
       },
       beforeOpen: (details) async {
         // Enable foreign keys

--- a/lib/database/tables/fuel_entries_table.dart
+++ b/lib/database/tables/fuel_entries_table.dart
@@ -42,6 +42,11 @@ class FuelEntries extends Table {
   /// and the fuel amount for this entry. Can be null for the first entry.
   RealColumn get consumption => real().nullable()();
 
+  /// Indicates whether this was a full tank fill-up or a partial refuel
+  /// Used for accurate consumption calculation - only full-to-full periods are used
+  /// First entry for a vehicle must always be a full tank
+  BoolColumn get isFullTank => boolean().withDefault(const Constant(true))();
+
   // Primary key is automatically set by autoIncrement()
 
   @override

--- a/lib/debug/web_auto_population.dart
+++ b/lib/debug/web_auto_population.dart
@@ -33,16 +33,15 @@ class WebAutoPopulation {
         return; // Data already exists, don't auto-populate other vehicles
       }
 
-      print('🚗 Auto-populating comprehensive test data with 6 diverse vehicles...');
+      print('🚗 Auto-populating comprehensive test data with 5 diverse vehicles...');
       
       await _createHondaCivic(ref);
       await _createToyotaHilux(ref);
-      await _createBMW320i(ref);
       await _createToyotaPrius(ref);
-      await _createMazdaMX5(ref);
+      await _createMixedRefuelTestVehicle(ref); // New mixed refuel test vehicle
       await _createTeslaModel3(ref); // New vehicle for year-spanning test
       
-      print('✅ Auto-populated 6 vehicles with 150+ comprehensive fuel entries');
+      print('✅ Auto-populated 5 vehicles with mixed refuel types for comprehensive testing');
     } catch (e) {
       print('❌ Failed to auto-populate data: $e');
     }
@@ -102,31 +101,84 @@ class WebAutoPopulation {
     );
   }
 
-  /// Create BMW 320i 2019 - Luxury sedan with moderate consumption
-  static Future<void> _createBMW320i(Ref ref) async {
+  /// Create Mixed Refuel Test Vehicle - Perfect for testing full/partial consumption periods
+  static Future<void> _createMixedRefuelTestVehicle(Ref ref) async {
     final vehicle = VehicleModel.create(
-      name: 'BMW 320i 2019',
-      initialKm: 32850.0,
+      name: 'Mixed Refuel Test Vehicle',
+      initialKm: 75000.0,
     );
 
     final createdVehicle = await ref.read(vehiclesNotifierProvider.notifier).addVehicle(vehicle);
     final fuelNotifier = ref.read(fuelEntriesNotifierProvider.notifier);
     
-    // Generate 22 entries over 13 months with 8.5-11 L/100km consumption
-    await _generateFuelEntries(
-      fuelNotifier,
-      createdVehicle.id!,
-      vehicle.initialKm,
-      vehicleName: 'BMW 320i',
-      entryCount: 22,
-      monthsSpan: 13,
-      baseConsumption: 9.75,
-      consumptionVariance: 1.25,
-      tankSize: 60.0,
-      countries: ['Germany', 'France', 'USA'],
-      currencies: ['EUR', 'EUR', 'USD'],
-      basePrices: [1.70, 1.68, 1.15], // EUR, EUR, USD per liter
-    );
+    // Create entries that demonstrate consumption periods clearly
+    final baseDate = DateTime.now().subtract(const Duration(days: 50));
+    
+    // Enhanced pattern for richer testing - spans 6 months with 8 complete periods
+    // Each period demonstrates different consumption scenarios across seasons
+    
+    final entries = [
+      // Period 1: Full -> Partial -> Full (city driving, winter)
+      {'days': -180, 'km': 75000.0, 'fuel': 55.0, 'price': 79.75, 'full': true, 'type': 'Full'},
+      {'days': -175, 'km': 75180.0, 'fuel': 25.0, 'price': 36.25, 'full': false, 'type': 'Partial'},
+      {'days': -170, 'km': 75380.0, 'fuel': 40.0, 'price': 58.00, 'full': true, 'type': 'Full'},
+      
+      // Period 2: Full -> Full (highway driving, winter)
+      {'days': -160, 'km': 75780.0, 'fuel': 48.0, 'price': 69.60, 'full': true, 'type': 'Full'},
+      
+      // Period 3: Full -> Partial -> Partial -> Full (mixed driving, late winter)
+      {'days': -145, 'km': 76200.0, 'fuel': 52.0, 'price': 75.40, 'full': true, 'type': 'Full'},
+      {'days': -135, 'km': 76450.0, 'fuel': 30.0, 'price': 43.50, 'full': false, 'type': 'Partial'},
+      {'days': -125, 'km': 76680.0, 'fuel': 28.0, 'price': 40.60, 'full': false, 'type': 'Partial'},
+      {'days': -115, 'km': 76920.0, 'fuel': 42.0, 'price': 60.90, 'full': true, 'type': 'Full'},
+      
+      // Period 4: Full -> Partial -> Full (spring efficiency improvement)
+      {'days': -100, 'km': 77350.0, 'fuel': 45.0, 'price': 65.25, 'full': true, 'type': 'Full'},
+      {'days': -85, 'km': 77650.0, 'fuel': 22.0, 'price': 31.90, 'full': false, 'type': 'Partial'},
+      {'days': -70, 'km': 77980.0, 'fuel': 38.0, 'price': 55.10, 'full': true, 'type': 'Full'},
+      
+      // Period 5: Full -> Full (summer efficiency, best consumption)
+      {'days': -55, 'km': 78420.0, 'fuel': 40.0, 'price': 58.00, 'full': true, 'type': 'Full'},
+      
+      // Period 6: Full -> Partial -> Full (summer, AC usage)
+      {'days': -40, 'km': 78800.0, 'fuel': 42.0, 'price': 60.90, 'full': true, 'type': 'Full'},
+      {'days': -30, 'km': 79120.0, 'fuel': 24.0, 'price': 34.80, 'full': false, 'type': 'Partial'},
+      {'days': -20, 'km': 79450.0, 'fuel': 36.0, 'price': 52.20, 'full': true, 'type': 'Full'},
+      
+      // Period 7: Full -> Partial -> Partial -> Full (fall, moderate consumption)
+      {'days': -10, 'km': 79850.0, 'fuel': 44.0, 'price': 63.80, 'full': true, 'type': 'Full'},
+      {'days': -5, 'km': 80100.0, 'fuel': 20.0, 'price': 29.00, 'full': false, 'type': 'Partial'},
+      {'days': 0, 'km': 80350.0, 'fuel': 25.0, 'price': 36.25, 'full': false, 'type': 'Partial'},
+      {'days': 5, 'km': 80600.0, 'fuel': 35.0, 'price': 50.75, 'full': true, 'type': 'Full'},
+      
+      // Period 8: Full -> Full (recent, efficient driving)
+      {'days': 15, 'km': 81020.0, 'fuel': 38.0, 'price': 55.10, 'full': true, 'type': 'Full'},
+      
+      // Incomplete Period 9: Full -> Partial (current, ongoing)
+      {'days': 25, 'km': 81350.0, 'fuel': 18.0, 'price': 26.10, 'full': false, 'type': 'Partial'},
+    ];
+    
+    for (int i = 0; i < entries.length; i++) {
+      final data = entries[i];
+      final pricePerLiter = (data['price'] as double) / (data['fuel'] as double);
+      
+      final entry = FuelEntryModel.create(
+        vehicleId: createdVehicle.id!,
+        date: baseDate.add(Duration(days: data['days'] as int)),
+        currentKm: data['km'] as double,
+        fuelAmount: data['fuel'] as double,
+        price: data['price'] as double,
+        country: 'Canada',
+        pricePerLiter: pricePerLiter,
+        consumption: null, // Will be calculated by periods
+        isFullTank: data['full'] as bool,
+      );
+      
+      await fuelNotifier.addFuelEntry(entry);
+      print('Created ${data['type']} refuel entry: ${data['fuel']}L at ${data['km']} km');
+    }
+    
+    print('✅ Created Mixed Refuel Test Vehicle with 8 complete periods + 1 incomplete (spans 6 months)');
   }
 
   /// Create Toyota Prius 2021 - Hybrid with very high efficiency
@@ -157,32 +209,6 @@ class WebAutoPopulation {
     );
   }
 
-  /// Create Mazda MX-5 2018 - Sports car with variable consumption
-  static Future<void> _createMazdaMX5(Ref ref) async {
-    final vehicle = VehicleModel.create(
-      name: 'Mazda MX-5 2018',
-      initialKm: 67420.0,
-    );
-
-    final createdVehicle = await ref.read(vehiclesNotifierProvider.notifier).addVehicle(vehicle);
-    final fuelNotifier = ref.read(fuelEntriesNotifierProvider.notifier);
-    
-    // Generate 24 entries over 15 months with 8-16 L/100km consumption (highly variable)
-    await _generateFuelEntries(
-      fuelNotifier,
-      createdVehicle.id!,
-      vehicle.initialKm,
-      vehicleName: 'Mazda MX-5',
-      entryCount: 24,
-      monthsSpan: 15,
-      baseConsumption: 12.0,
-      consumptionVariance: 4.0, // High variance for sports car (city vs highway)
-      tankSize: 45.0,
-      countries: ['Australia', 'Japan', 'Canada'],
-      currencies: ['AUD', 'JPY', 'CAD'],
-      basePrices: [1.80, 165.0, 1.62], // AUD, JPY, CAD per liter
-    );
-  }
 
   /// Create Tesla Model 3 2023 - Electric vehicle with year-spanning data for testing
   static Future<void> _createTeslaModel3(Ref ref) async {
@@ -258,6 +284,7 @@ class WebAutoPopulation {
         country: 'Canada',
         pricePerLiter: pricePerLiter,
         consumption: actualConsumption,
+        isFullTank: true, // Tesla Model 3 - all entries are "full charges"
       );
       
       await fuelNotifier.addFuelEntry(entry);
@@ -333,6 +360,7 @@ class WebAutoPopulation {
         country: country,
         pricePerLiter: pricePerLiter,
         consumption: consumption,
+        isFullTank: i == 0 ? true : (i % 4 != 2), // First must be full, then realistic mix (75% full, 25% partial)
       );
       
       await fuelNotifier.addFuelEntry(entry);

--- a/lib/debug/web_data_injector.dart
+++ b/lib/debug/web_data_injector.dart
@@ -304,6 +304,7 @@ class _DataInjectionDialogState extends State<DataInjectionDialog> {
           country: 'Canada',
           pricePerLiter: 1.45,
           consumption: i == 0 ? null : 10.0 + (i * 0.5), // First entry has no consumption
+          isFullTank: i == 0 ? true : (i % 3 != 1), // First entry must be full tank, then mix
         );
         
         await fuelNotifier.addFuelEntry(entry);
@@ -375,6 +376,7 @@ class _DataInjectionDialogState extends State<DataInjectionDialog> {
             data['km']!,
             data['liters']!,
           ),
+          isFullTank: i == 0 ? true : (i % 4 != 2), // First must be full, then realistic mix
         );
         
         await fuelNotifier.addFuelEntry(entry);
@@ -431,6 +433,7 @@ class _DataInjectionDialogState extends State<DataInjectionDialog> {
           country: i % 3 == 0 ? 'USA' : 'Canada',
           pricePerLiter: 1.40 + (i * 0.02),
           consumption: i == 0 ? null : 8.5 + (i % 5),
+          isFullTank: i == 0 ? true : (i % 5 != 2), // First must be full, then varied mix
         );
         
         await fuelNotifier.addFuelEntry(entry);

--- a/lib/models/fuel_entry_model.dart
+++ b/lib/models/fuel_entry_model.dart
@@ -12,6 +12,7 @@ class FuelEntryModel {
   final String country;
   final double pricePerLiter;
   final double? consumption;
+  final bool isFullTank;
 
   const FuelEntryModel({
     this.id,
@@ -23,6 +24,7 @@ class FuelEntryModel {
     required this.country,
     required this.pricePerLiter,
     this.consumption,
+    this.isFullTank = true,
   });
 
   /// Creates a FuelEntryModel from a Drift FuelEntry entity
@@ -37,6 +39,7 @@ class FuelEntryModel {
       country: entity.country,
       pricePerLiter: entity.pricePerLiter,
       consumption: entity.consumption,
+      isFullTank: entity.isFullTank,
     );
   }
 
@@ -50,6 +53,7 @@ class FuelEntryModel {
     required String country,
     required double pricePerLiter,
     double? consumption,
+    bool isFullTank = true,
   }) {
     return FuelEntryModel(
       vehicleId: vehicleId,
@@ -60,20 +64,22 @@ class FuelEntryModel {
       country: country,
       pricePerLiter: pricePerLiter,
       consumption: consumption,
+      isFullTank: isFullTank,
     );
   }
 
   /// Converts to Drift FuelEntriesCompanion for database operations
   FuelEntriesCompanion toCompanion() {
-    return FuelEntriesCompanion.insert(
-      vehicleId: vehicleId,
-      date: date,
-      currentKm: currentKm,
-      fuelAmount: fuelAmount,
-      price: price,
-      country: country,
-      pricePerLiter: pricePerLiter,
+    return FuelEntriesCompanion(
+      vehicleId: Value(vehicleId),
+      date: Value(date),
+      currentKm: Value(currentKm),
+      fuelAmount: Value(fuelAmount),
+      price: Value(price),
+      country: Value(country),
+      pricePerLiter: Value(pricePerLiter),
       consumption: Value(consumption),
+      isFullTank: Value(isFullTank),
     );
   }
 
@@ -89,6 +95,7 @@ class FuelEntryModel {
       country: Value(country),
       pricePerLiter: Value(pricePerLiter),
       consumption: Value(consumption),
+      isFullTank: Value(isFullTank),
     );
   }
 
@@ -117,12 +124,17 @@ class FuelEntryModel {
   }
 
   /// Validates fuel entry data
-  List<String> validate({double? previousKm}) {
+  List<String> validate({double? previousKm, bool isFirstEntry = false}) {
     final errors = <String>[];
 
     // Vehicle ID validation
     if (vehicleId <= 0) {
       errors.add('Vehicle ID must be valid');
+    }
+
+    // First entry must be full tank
+    if (isFirstEntry && !isFullTank) {
+      errors.add('First fuel entry for a vehicle must be a full tank fill-up');
     }
 
     // Date validation
@@ -181,7 +193,7 @@ class FuelEntryModel {
   }
 
   /// Returns true if the fuel entry data is valid
-  bool isValid({double? previousKm}) => validate(previousKm: previousKm).isEmpty;
+  bool isValid({double? previousKm, bool isFirstEntry = false}) => validate(previousKm: previousKm, isFirstEntry: isFirstEntry).isEmpty;
 
   /// Calculated properties
   
@@ -211,6 +223,7 @@ class FuelEntryModel {
     String? country,
     double? pricePerLiter,
     double? consumption,
+    bool? isFullTank,
   }) {
     return FuelEntryModel(
       id: id ?? this.id,
@@ -222,6 +235,7 @@ class FuelEntryModel {
       country: country ?? this.country,
       pricePerLiter: pricePerLiter ?? this.pricePerLiter,
       consumption: consumption ?? this.consumption,
+      isFullTank: isFullTank ?? this.isFullTank,
     );
   }
 
@@ -237,7 +251,8 @@ class FuelEntryModel {
         other.price == price &&
         other.country == country &&
         other.pricePerLiter == pricePerLiter &&
-        other.consumption == consumption;
+        other.consumption == consumption &&
+        other.isFullTank == isFullTank;
   }
 
   @override
@@ -252,11 +267,12 @@ class FuelEntryModel {
       country,
       pricePerLiter,
       consumption,
+      isFullTank,
     );
   }
 
   @override
   String toString() {
-    return 'FuelEntryModel(id: $id, vehicleId: $vehicleId, date: $date, currentKm: $currentKm, fuelAmount: $fuelAmount, price: $price, country: $country, pricePerLiter: $pricePerLiter, consumption: $consumption)';
+    return 'FuelEntryModel(id: $id, vehicleId: $vehicleId, date: $date, currentKm: $currentKm, fuelAmount: $fuelAmount, price: $price, country: $country, pricePerLiter: $pricePerLiter, consumption: $consumption, isFullTank: $isFullTank)';
   }
 }

--- a/lib/providers/chart_providers.g.dart
+++ b/lib/providers/chart_providers.g.dart
@@ -7,7 +7,7 @@ part of 'chart_providers.dart';
 // **************************************************************************
 
 String _$consumptionChartDataHash() =>
-    r'473bb4d1f0afe3e1d9524ecacf6dcce9f08f4c17';
+    r'a479704261fd7d33c8a7c47c51386695c2058611';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -31,22 +31,26 @@ class _SystemHash {
 }
 
 /// Provider for consumption chart data for a specific vehicle
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionChartData].
 @ProviderFor(consumptionChartData)
 const consumptionChartDataProvider = ConsumptionChartDataFamily();
 
 /// Provider for consumption chart data for a specific vehicle
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionChartData].
 class ConsumptionChartDataFamily
     extends Family<AsyncValue<List<ConsumptionDataPoint>>> {
   /// Provider for consumption chart data for a specific vehicle
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionChartData].
   const ConsumptionChartDataFamily();
 
   /// Provider for consumption chart data for a specific vehicle
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionChartData].
   ConsumptionChartDataProvider call(
@@ -91,11 +95,13 @@ class ConsumptionChartDataFamily
 }
 
 /// Provider for consumption chart data for a specific vehicle
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionChartData].
 class ConsumptionChartDataProvider
     extends AutoDisposeFutureProvider<List<ConsumptionDataPoint>> {
   /// Provider for consumption chart data for a specific vehicle
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionChartData].
   ConsumptionChartDataProvider(
@@ -1859,25 +1865,29 @@ class _PeriodAverageConsumptionDataProviderElement
 }
 
 String _$consumptionStatisticsHash() =>
-    r'8d440d9f6844a129ba185490099cb1ab2475b852';
+    r'362dd492f2fbe29d44e2828c95d5cfb1e6d6233f';
 
 /// Provider for overall consumption statistics
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionStatistics].
 @ProviderFor(consumptionStatistics)
 const consumptionStatisticsProvider = ConsumptionStatisticsFamily();
 
 /// Provider for overall consumption statistics
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionStatistics].
 class ConsumptionStatisticsFamily
     extends Family<AsyncValue<Map<String, double>>> {
   /// Provider for overall consumption statistics
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionStatistics].
   const ConsumptionStatisticsFamily();
 
   /// Provider for overall consumption statistics
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionStatistics].
   ConsumptionStatisticsProvider call(
@@ -1922,11 +1932,13 @@ class ConsumptionStatisticsFamily
 }
 
 /// Provider for overall consumption statistics
+/// Uses period-based consumption calculation (full tank to full tank)
 ///
 /// Copied from [consumptionStatistics].
 class ConsumptionStatisticsProvider
     extends AutoDisposeFutureProvider<Map<String, double>> {
   /// Provider for overall consumption statistics
+  /// Uses period-based consumption calculation (full tank to full tank)
   ///
   /// Copied from [consumptionStatistics].
   ConsumptionStatisticsProvider(

--- a/lib/services/consumption_calculation_service.dart
+++ b/lib/services/consumption_calculation_service.dart
@@ -1,0 +1,220 @@
+import 'package:petrol_tracker/models/fuel_entry_model.dart';
+
+/// Represents a consumption period from one full tank to another
+class ConsumptionPeriod {
+  final FuelEntryModel startFullTank;
+  final FuelEntryModel endFullTank;
+  final List<FuelEntryModel> partialEntries;
+  final double totalFuel;
+  final double totalDistance;
+  final double consumption;
+  final double totalCost;
+
+  const ConsumptionPeriod({
+    required this.startFullTank,
+    required this.endFullTank,
+    required this.partialEntries,
+    required this.totalFuel,
+    required this.totalDistance,
+    required this.consumption,
+    required this.totalCost,
+  });
+
+  /// Get all entries in this period (partials + end full tank)
+  List<FuelEntryModel> get allEntries => [...partialEntries, endFullTank];
+
+  /// Formatted consumption string
+  String get formattedConsumption => '${consumption.toStringAsFixed(1)} L/100km';
+
+  /// Formatted total cost string
+  String get formattedTotalCost => '\$${totalCost.toStringAsFixed(2)}';
+
+  /// Period description for UI
+  String get periodDescription {
+    final startDate = startFullTank.date;
+    final endDate = endFullTank.date;
+    final days = endDate.difference(startDate).inDays;
+    return '${totalDistance.toStringAsFixed(0)} km over $days days';
+  }
+}
+
+/// Service for calculating fuel consumption using full tank to full tank periods
+class ConsumptionCalculationService {
+  /// Calculate consumption periods from a list of fuel entries
+  /// Only calculates consumption between full tank entries
+  static List<ConsumptionPeriod> calculateConsumptionPeriods(List<FuelEntryModel> entries) {
+    final periods = <ConsumptionPeriod>[];
+    
+    // Sort entries by date to ensure proper order
+    final sortedEntries = List<FuelEntryModel>.from(entries)
+      ..sort((a, b) => a.date.compareTo(b.date));
+    
+    FuelEntryModel? lastFullTank;
+    List<FuelEntryModel> currentPartials = [];
+    
+    for (final entry in sortedEntries) {
+      if (entry.isFullTank) {
+        if (lastFullTank != null) {
+          // Create consumption period from last full tank to this one
+          final period = _createConsumptionPeriod(
+            startFullTank: lastFullTank,
+            endFullTank: entry,
+            partialEntries: currentPartials,
+          );
+          periods.add(period);
+        }
+        lastFullTank = entry;
+        currentPartials.clear();
+      } else {
+        currentPartials.add(entry);
+      }
+    }
+    
+    return periods;
+  }
+
+  /// Create a single consumption period
+  static ConsumptionPeriod _createConsumptionPeriod({
+    required FuelEntryModel startFullTank,
+    required FuelEntryModel endFullTank,
+    required List<FuelEntryModel> partialEntries,
+  }) {
+    // Calculate total fuel added (partials + end full tank)
+    final totalFuel = partialEntries.fold<double>(0, (sum, entry) => sum + entry.fuelAmount) + 
+                     endFullTank.fuelAmount;
+    
+    // Calculate total distance
+    final totalDistance = endFullTank.currentKm - startFullTank.currentKm;
+    
+    // Calculate consumption (L/100km)
+    final consumption = totalDistance > 0 ? (totalFuel / totalDistance) * 100 : 0.0;
+    
+    // Calculate total cost (partials + end full tank)
+    final totalCost = partialEntries.fold<double>(0, (sum, entry) => sum + entry.price) + 
+                     endFullTank.price;
+    
+    return ConsumptionPeriod(
+      startFullTank: startFullTank,
+      endFullTank: endFullTank,
+      partialEntries: partialEntries,
+      totalFuel: totalFuel,
+      totalDistance: totalDistance,
+      consumption: consumption,
+      totalCost: totalCost,
+    );
+  }
+
+  /// Get consumption data points for charts (one point per period)
+  static List<Map<String, dynamic>> getConsumptionDataPoints(List<ConsumptionPeriod> periods) {
+    return periods.map((period) => {
+      'date': period.endFullTank.date.toIso8601String().split('T')[0],
+      'value': period.consumption,
+      'km': period.endFullTank.currentKm,
+      'fuel': period.totalFuel,
+      'cost': period.totalCost,
+      'distance': period.totalDistance,
+      'startDate': period.startFullTank.date.toIso8601String().split('T')[0],
+      'endDate': period.endFullTank.date.toIso8601String().split('T')[0],
+      'entryCount': period.allEntries.length,
+    }).toList();
+  }
+
+  /// Calculate statistics from consumption periods
+  static Map<String, double> calculateStatistics(List<ConsumptionPeriod> periods) {
+    if (periods.isEmpty) {
+      return {
+        'average': 0.0,
+        'minimum': 0.0,
+        'maximum': 0.0,
+        'totalDistance': 0.0,
+        'totalFuel': 0.0,
+        'totalCost': 0.0,
+      };
+    }
+
+    final consumptions = periods.map((p) => p.consumption).toList();
+    final average = consumptions.reduce((a, b) => a + b) / consumptions.length;
+    final minimum = consumptions.reduce((a, b) => a < b ? a : b);
+    final maximum = consumptions.reduce((a, b) => a > b ? a : b);
+    
+    final totalDistance = periods.fold<double>(0, (sum, p) => sum + p.totalDistance);
+    final totalFuel = periods.fold<double>(0, (sum, p) => sum + p.totalFuel);
+    final totalCost = periods.fold<double>(0, (sum, p) => sum + p.totalCost);
+
+    return {
+      'average': average,
+      'minimum': minimum,
+      'maximum': maximum,
+      'totalDistance': totalDistance,
+      'totalFuel': totalFuel,
+      'totalCost': totalCost,
+    };
+  }
+
+  /// Update fuel entries with period-based consumption calculations
+  /// This replaces the old individual entry consumption values
+  static List<FuelEntryModel> updateEntriesWithPeriodConsumption(
+    List<FuelEntryModel> entries,
+    List<ConsumptionPeriod> periods,
+  ) {
+    final updatedEntries = <FuelEntryModel>[];
+    
+    // Create a map of entry ID to consumption period
+    final entryToPeriod = <int, ConsumptionPeriod>{};
+    for (final period in periods) {
+      for (final entry in period.allEntries) {
+        if (entry.id != null) {
+          entryToPeriod[entry.id!] = period;
+        }
+      }
+    }
+    
+    // Update entries with period consumption
+    for (final entry in entries) {
+      if (entry.id != null && entryToPeriod.containsKey(entry.id)) {
+        final period = entryToPeriod[entry.id!]!;
+        // Only assign consumption to the end full tank entry of each period
+        final consumption = entry.id == period.endFullTank.id ? period.consumption : null;
+        updatedEntries.add(entry.copyWith(consumption: consumption));
+      } else {
+        // Entry not part of any complete period (e.g., last entry is partial)
+        updatedEntries.add(entry.copyWith(consumption: null));
+      }
+    }
+    
+    return updatedEntries;
+  }
+
+  /// Check if there are any incomplete periods (partial entries without following full tank)
+  static bool hasIncompletePeriods(List<FuelEntryModel> entries) {
+    final sortedEntries = List<FuelEntryModel>.from(entries)
+      ..sort((a, b) => a.date.compareTo(b.date));
+    
+    // If last entry is not a full tank, there's an incomplete period
+    return sortedEntries.isNotEmpty && !sortedEntries.last.isFullTank;
+  }
+
+  /// Get entries that are part of incomplete periods
+  static List<FuelEntryModel> getIncompletePeriodsEntries(List<FuelEntryModel> entries) {
+    final sortedEntries = List<FuelEntryModel>.from(entries)
+      ..sort((a, b) => a.date.compareTo(b.date));
+    
+    final incompleteEntries = <FuelEntryModel>[];
+    
+    // Find the last full tank entry
+    int lastFullTankIndex = -1;
+    for (int i = sortedEntries.length - 1; i >= 0; i--) {
+      if (sortedEntries[i].isFullTank) {
+        lastFullTankIndex = i;
+        break;
+      }
+    }
+    
+    // If there are entries after the last full tank, they're incomplete
+    if (lastFullTankIndex >= 0 && lastFullTankIndex < sortedEntries.length - 1) {
+      incompleteEntries.addAll(sortedEntries.sublist(lastFullTankIndex + 1));
+    }
+    
+    return incompleteEntries;
+  }
+}


### PR DESCRIPTION
## Summary
• Implements proper fuel consumption calculation using full-tank-to-full-tank periods instead of individual entry calculations
• Adds `is_full_tank` field to database schema with migration from v1 to v2
• Enforces first fuel entry must be a full tank with validation and UI warnings
• Creates period-based consumption calculation service for accurate fuel efficiency tracking
• Updates UI with full tank toggle and smart validation indicators
• Integrates new consumption logic with chart providers and statistics

## Technical Implementation
• **Database Schema**: Added `is_full_tank` boolean column with default `true` and proper migration
• **Consumption Logic**: New `ConsumptionCalculationService` calculates consumption between complete periods (full-to-full tank)
• **Model Enhancement**: `FuelEntryModel` includes `isFullTank` field with comprehensive validation
• **UI Updates**: Fuel entry form includes toggle with disabled state for first entries
• **Chart Integration**: Updated `consumptionChartDataProvider` and `consumptionStatistics` to use period-based calculation
• **Test Data**: Enhanced debug injector with 8 complete consumption periods spanning 6 months

## Key Files Modified
• `lib/database/tables/fuel_entries_table.dart` - Added `isFullTank` column
• `lib/database/database.dart` - Schema v2 migration  
• `lib/models/fuel_entry_model.dart` - Enhanced with validation
• `lib/services/consumption_calculation_service.dart` - **NEW** Period calculation logic
• `lib/screens/add_fuel_entry_screen.dart` - UI with full tank toggle
• `lib/providers/chart_providers.dart` - Updated to use period-based calculation
• `lib/debug/web_auto_population.dart` - Enhanced test data with mixed refuel patterns

## Problem Solved
**Before**: Individual fuel entries calculated consumption independently, leading to inaccurate measurements when users did partial refuels or didn't fill completely to the brim.

**After**: Only complete periods (full tank → [partial refuels] → full tank) generate consumption data points, providing accurate fuel efficiency measurements that match real-world scenarios.

## Test Plan
- [x] Database migration from v1 to v2 preserves existing data
- [x] First entry validation prevents non-full-tank initial entries  
- [x] Mixed refuel scenarios calculate accurate consumption periods
- [x] Chart integration displays period-based consumption values correctly
- [x] Form validation provides clear feedback for full tank requirements
- [x] Enhanced test data with 8 periods demonstrates seasonal variations
- [x] Time period filtering works correctly with period-based data
- [x] Statistics calculated from complete consumption periods

## Demo Data
The "Mixed Refuel Test Vehicle" demonstrates the new logic with:
- **8 complete consumption periods** spanning 6 months
- **Seasonal consumption variations** (winter: ~12-16 L/100km, summer: ~9-11 L/100km)
- **Different refuel patterns** (Full→Full, Full→Partial→Full, Full→Partial→Partial→Full)
- **Time-based filtering** showing appropriate data subsets

## Related Issues
- Fixes #86 - Fuel consumption calculation with full/partial tank tracking
- Created #87 - Navigation error when editing fuel entries
- Created #88 - Vehicle detail screen filtering issue
- Created #89 - Missing full/partial tank indicators in entry list

🤖 Generated with [Claude Code](https://claude.ai/code)