### PR TITLE
Fix navigation error when clicking back button from edit screen (Issue #87)

### DIFF
--- a/lib/navigation/main_layout.dart
+++ b/lib/navigation/main_layout.dart
@@ -137,7 +137,7 @@ class NavAppBar extends StatelessWidget implements PreferredSizeWidget {
       leading: showBackButton 
         ? IconButton(
             icon: const Icon(Icons.arrow_back),
-            onPressed: () => context.pop(),
+            onPressed: () => _handleBackNavigation(context),
           )
         : leading,
       actions: actions,
@@ -148,4 +148,30 @@ class NavAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  /// Handle back navigation with fallback for shell routes
+  /// 
+  /// Tries to pop the current route, and if that fails (indicating we're at
+  /// a top-level shell route), navigates back to the most appropriate screen.
+  /// For the add-entry screen, this typically means going back to entries.
+  void _handleBackNavigation(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      // Fallback for shell routes where there's nothing to pop
+      // Determine appropriate fallback based on current location
+      final currentLocation = GoRouterState.of(context).uri.path;
+      
+      switch (currentLocation) {
+        case '/add-entry':
+          // When editing/adding entries, go back to entries list
+          context.go('/entries');
+          break;
+        default:
+          // For other screens, go to dashboard as safe fallback
+          context.go('/');
+          break;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- ✅ Fixed GoRouter "There is nothing to pop" exception in NavAppBar back button
- ✅ Added smart navigation fallback for shell routes without navigation stack  
- ✅ Implemented context-aware routing based on current screen
- ✅ Maintains intuitive user experience when editing fuel entries

## Problem Description
Users experienced a GoRouter exception when:
1. Clicking on a fuel entry to view details
2. Pressing the "Edit" button (navigates to `/add-entry`)  
3. Clicking the back arrow in the top-right corner
4. App throws `GoError: There is nothing to pop`

## Root Cause
The issue occurred because:
- Both `/entries` and `/add-entry` are sibling routes under the same `ShellRoute`
- Navigation between them using `context.go()` doesn't create a navigation stack
- `NavAppBar` was calling `context.pop()` without checking if there's anything to pop

## Solution
Enhanced `NavAppBar._handleBackNavigation()` with:
- **Safety Check**: `context.canPop()` validation before attempting to pop
- **Smart Fallback**: Context-aware navigation when no stack exists
- **Logical Flow**: `/add-entry` → `/entries` (most intuitive for users)
- **Safe Default**: Other screens → `/` (dashboard fallback)

## Test Results
- ✅ Flutter build successful
- ✅ Static analysis clean (no new errors)
- ✅ Existing NavAppBar unit tests pass
- ✅ Navigation structure preserved  
- ✅ Back button functionality improved without breaking changes

## Testing Steps
1. Navigate to fuel entries list
2. Click on any fuel entry → Press "Edit" button  
3. Click back arrow in NavAppBar
4. Verify smooth navigation to entries list (no exception)

🤖 Generated with [Claude Code](https://claude.ai/code)