### PR TITLE
Reduce area chart grid opacity for better visual consistency - Issue #114

### DIFF
--- a/lib/widgets/chart_webview.dart
+++ b/lib/widgets/chart_webview.dart
@@ -520,11 +520,11 @@ class _ChartWebViewState extends ConsumerState<ChartWebView> {
                       .curve(d3.curveMonotoneX);
                   console.log('Generators created');
                   
-                  // Add visible horizontal grid lines first (behind everything)
+                  // Add subtle horizontal grid lines first (behind everything)
                   console.log('Adding horizontal grid lines...');
                   g.append('g')
                       .attr('class', 'grid horizontal-grid')
-                      .attr('opacity', 0.5)
+                      .attr('opacity', 0.2)
                       .call(d3.axisLeft(yScale)
                           .tickValues(yTickValues)
                           .tickSize(-width)
@@ -532,11 +532,11 @@ class _ChartWebViewState extends ConsumerState<ChartWebView> {
                       );
                   console.log('Horizontal grid lines added');
                   
-                  // Add visible vertical grid lines
+                  // Add subtle vertical grid lines
                   console.log('Adding vertical grid lines...');
                   g.append('g')
                       .attr('class', 'grid vertical-grid')
-                      .attr('opacity', 0.5)
+                      .attr('opacity', 0.2)
                       .attr('transform', 'translate(0,' + height + ')')
                       .call(d3.axisBottom(xScale)
                           .tickValues(xTickValues)


### PR DESCRIPTION
## Summary
Reduces the area chart grid opacity to make it more subtle and visually consistent with dashboard design principles.

## Changes Made
- **Grid opacity**: Reduced from `0.5` to `0.2` for both horizontal and vertical grid lines in area chart
- **Visual improvement**: Grid lines are now more subtle and don't compete with chart data
- **Comments updated**: Reflect the new "subtle" grid styling approach

## Technical Details
- Modified `chart_webview.dart` in the custom `renderAreaChart` method
- Changed `.attr('opacity', 0.5)` to `.attr('opacity', 0.2)` for grid elements
- Maintains all existing functionality while improving visual appearance

## Expected Result
- Area chart grid lines are now more subtle and professional-looking  
- Grid provides visual structure without overwhelming the chart data
- Better visual harmony across the dashboard charts

## Testing
- [x] Area chart renders correctly with new grid opacity
- [x] Bar chart remains unchanged (as expected)
- [x] Grid lines are visible but subtle
- [x] No regressions in chart functionality
- [x] Charts work correctly across different data scenarios

## Acceptance Criteria
- [x] Area chart grid opacity reduced to more subtle level
- [x] Grid lines remain visible enough to be useful
- [x] No duplicate or dead code introduced
- [x] Consistent implementation maintained
- [x] Visual improvement achieved without functional changes

Closes #114

🤖 Generated with [Claude Code](https://claude.ai/code)